### PR TITLE
Fix publish docker on release

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -16,7 +16,7 @@ on:
 env:
   REGISTRY: ghcr.io
   TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
-  pathPrefix: ${{ github.event.inputs.pathPrefix || "/stac-browser/" }}
+  pathPrefix: ${{ github.event.inputs.pathPrefix || '/stac-browser/' }}
 
 jobs:
   retag-docker-image:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -16,7 +16,7 @@ on:
 env:
   REGISTRY: ghcr.io
   TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
-  pathPrefix: ${{ github.event.inputs.pathPrefix }}
+  pathPrefix: ${{ github.event.inputs.pathPrefix || "/stac-browser/" }}
 
 jobs:
   retag-docker-image:


### PR DESCRIPTION
The default `pathPrefix` value is only set when `workflow_dispatch` actions are run.
This action is also triggered on `release` and then `pathPrefix` is set to the empty string for this action run.
This means that an incorrect nginx location block is created:

```nginx
    location  {  # <- pathPrefix value goes here but since it is empty there is no value for the location block
        alias  /usr/share/nginx/html/;
        index  index.html;
        try_files $uri $uri/ /index.html;
    }
```

This fixes this issue by setting a default value for pathPrefix that is always applied even if the action is triggered without the workflow-dispatch variables.

Note that this means that the docker image currently tagged  `4.0.0-rc.2-crim` crashes immediately (due to an invalid nginx conf file). I recommend that as a temporary fix we re-do that docker image (as a workflow-dispatch action) so that it works.